### PR TITLE
Update CPython version and SIP build configuration

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.11.1"
+version: "5.11.1-alpha.0"
 requirements:
   - "savitar/5.11.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.11.0-alpha.0"
+version: "5.12.0-alpha.0"
 requirements:
   - "savitar/5.11.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.12.0-alpha.0"
+version: "5.11.1-alpha.0"
 requirements:
   - "savitar/5.11.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.11.1-alpha.0"
+version: "5.11.1"
 requirements:
   - "savitar/5.11.0-alpha.0"

--- a/conanfile.py
+++ b/conanfile.py
@@ -69,7 +69,7 @@ class PySavitarConan(ConanFile):
     def requirements(self):
         for req in self.conan_data["requirements"]:
             self.requires(req)
-        self.requires("cpython/3.12.2")
+        self.requires("cpython/3.12.7")
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -116,7 +116,9 @@ class PySavitarConan(ConanFile):
 
         # Generate the Source code from SIP
         sip = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        sip.configure()
+        # Use the full path to sip-build from the CPython Scripts directory
+        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
+        sip.configure(sip_install_executable=sip_build_path)
         sip.build()
 
     def layout(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -116,9 +116,8 @@ class PySavitarConan(ConanFile):
 
         # Generate the Source code from SIP
         sip = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        # Use the full path to sip-build from the CPython Scripts directory
-        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
-        sip.configure(sip_install_executable=sip_build_path)
+        # Auto-detect sip-build from CPython dependency (cross-platform)
+        sip.configure(cpython_dependency=self.dependencies["cpython"])
         sip.build()
 
     def layout(self):


### PR DESCRIPTION
This pull request updates the `cpython` dependency version and improves the SIP build configuration to use the correct executable path. The most important changes are grouped below:

Dependency update:

* Updated the required version of `cpython` from `3.12.2` to `3.12.7` in the `requirements` method of `conanfile.py`.

Build configuration improvements:

* Modified the SIP build process in the `generate` method to explicitly use the full path to `sip-build.exe` from the CPython Scripts directory, ensuring the correct executable is used during source generation.

CURA-12814